### PR TITLE
Updated release requirements

### DIFF
--- a/proposals/PIP002-Releases.md
+++ b/proposals/PIP002-Releases.md
@@ -12,26 +12,13 @@ Only maintainer committees can make releases.
 ## Release approval
 
 The maintainer committee must approve a release. 
-A majority vote is required for a release to be approved.
-At a minimum, three maintainers must vote positively on a release.
+Each project must have a stated process for this approval. 
 
-Individual maintainers cannot veto a releases. 
 Non-binding votes are encouraged as a sign of good community health.
-
-Individuals who vote on a project must download all 
-signed source code packages to their hardware, 
-verify they meet all requirements, check cryptographic signatures,
-compile the code, and run tests.
-
-Release votes are open for at least 72 hours.
-
-Votes are carried out as described in the "Voting" proposal.
 
 ## Publication
 
-Projects must publish official releases to the public 
-but shall not publish unreleased materials outside 
-the development community.
+Projects must publish official releases to the public.
 
 Projects should encourage release testing by the community
 by providing pre-release versions and instructions.
@@ -46,8 +33,8 @@ A source release does not contain compiled code.
 
 ### Release Signing
 
-The release manager or automated tools must cryptographically sign all packages.
-All packages must use a detached signature.
+The release manager or automated tools should be cryptographically sign all packages.
+All packages should use a detached signature.
 
 ### Compiled packages
 
@@ -55,7 +42,7 @@ Projects may provide compiled packages for convenience.
 It is not required to provide compiled packages.
 
 If a project decides to provide compiled packages, 
-they must be signed with the same key as the source packages.
+they should be signed with the same key as the source packages.
 In addition, they must have the same version number as the source packages.
 
 ## Licensing
@@ -74,7 +61,7 @@ Unnecessary information must not be included in the `LICENSE` file.
 
 ### License Headers
 
-Every source file must contain the following license header:
+Every source file should contain the following license header:
 
 > Licensed to the Apache Software Foundation (ASF) under one
 > or more contributor license agreements.  See the NOTICE file
@@ -99,27 +86,6 @@ Every source file must contain the following license header:
 
 Other notices must be included if required by the license of packages included in the release.
 No other information is allowed in the `NOTICE` file.
-
-## Release distribution
-
-Once a release is approved, all artifacts must be uploaded to the one
-canonical PRAGMA distribution channel: downloads.pragma.io.
-
-Every project has its directory on the server.
-A maintainer committee is responsible for this directory.
-All releases must be signed.
-
-The release channel should only contain the latest release of a project.
-The project can do so if there are good reasons to keep older releases.
-
-## Release archival
-
-If releases are removed from the distribution channel, they must be archived
-in the archive server: archive.pragma.io
-
-The same rules apply to the usual release distribution.
-
-Archived packages must never be deleted.
 
 ## Policy administration
 


### PR DESCRIPTION
Removed voting components and updated parts that did not apply to us and would require additional projects to implement, i.e. signatures. Replaced several musts with should. These can be revisited if appropriate projects are put in place to support them.