### PR TITLE
Add minutes for Validity Review 20 meeting

### DIFF
--- a/2026-04-08.md
+++ b/2026-04-08.md
@@ -1,0 +1,81 @@
+---
+Name: Validity Review 20
+Date: Wednesday, 8 April 2026
+Time: 14:00 UTC
+Location: Online (videocall)
+---
+
+## Present
+
+- Benjamin Bürgi [@Bebu22](https://github.com/Bebu22)
+- Christina Gianelloni [@musik-c](https://github.com/musik-c)
+- Dan Gonzalez [@gonzalaga](https://github.com/gonzalaga)
+- Federico Weill [@federicoweill](https://github.com/federicoweill)
+- Beatrice Anihiri [@opacular](https://github.com/opacular) (secretary)
+
+## Not Present
+
+- Jeni Davidson [@Jenisis](https://github.com/Jenisis)
+- Marek Mahut [@mmahut](https://github.com/mmahut)
+
+---
+
+## Agenda
+
+### 1. Project Committee Update
+
+The board noted that the Project Committee is currently in a slower period. No formal update was provided.
+
+### 2. PRAGMA Goals Document
+
+The board reviewed the status of the PRAGMA goals document. The document has been circulated, and feedback from General Assembly members is visible. The board discussed whether it had authority to approve the goals document independently or whether approval should come from the General Assembly. It was agreed that the board would formally endorse the document and that it would be presented to the General Assembly at the annual meeting for their review and input. The board expressed support for the document and had no outstanding changes to propose.
+
+### 3. Maintainer Committee – Outstanding Reports
+
+The board discussed outstanding quarterly reports from the Maintainer Committee. The project lead responsible for the reports has communicated that he is currently occupied with significant external demands on his time. The board agreed to grant additional time, allowing a further month for the reports to be submitted. 
+### 4. Shared Password Manager
+
+The board discussed the ongoing question of implementing a shared password manager across all PRAGMA projects. Pricing for two options was reviewed: one tool at $4 per seat and another at $8 per seat, based on an estimated 30 seats. The board agreed to present both options to the General Assembly along with the respective pricing, recommend the lower-cost option, and request that the General Assembly make the final decision on which tool to adopt and enforce uniformly across all projects.
+
+### 5. Accounting Update
+
+The board received an update on the ongoing financial audit with the external accounting firm. Remaining questions relating to VAT provisions are being addressed, and the audit is expected to be completed ahead of the annual meeting. The board also discussed an outstanding invoice, and it was agreed that another attempt would be made to initiate the payment through the system.
+
+### 6. Legal Update
+
+The board received a brief legal update. A legal matter that had been under review is now progressing, with counsel having received feedback and awaiting a response from the opposing party. Additionally, the board noted that a PRAGMA project is in direct contact with legal counsel to review a contract; the associated costs are to be billed directly to the project's own budget and not to PRAGMA.
+
+### 7. Quarterly Board Meeting
+
+The board agreed to schedule a quarterly meeting for Wednesday, 29 April 2026. Calendar invitations will be circulated to relevant attendees.
+
+### 8. Next Regular Meeting
+
+The board confirmed that the next regular monthly meeting will take place on Monday, 13 April 2026.
+
+
+### 9. Open Coding Session – Format and Categories
+
+The board noted that an outstanding action item regarding the format and categories for open coding sessions remains unresolved. A board member confirmed that follow-ups would continue and that a reminder had been added to their calendar.
+
+### 10. PRAGMA Board Discord Server
+
+The board noted that a prior decision to remove the PRAGMA board Discord server remains pending. Before proceeding with the removal, it was agreed that legal counsel should first be consulted to confirm there are no legal requirements mandating a permanently tracked communication channel.
+
+### 11. February Meeting Minutes
+
+The board noted that the February meeting minutes have been submitted as a pull request in the repository. One additional approval is required before the commit can be merged. Board members were asked to review and approve.
+
+---
+
+## Follow Up Notes
+
+The meeting concluded at approximately 15:00 UTC. The following items are carried forward:
+
+- PRAGMA goals document – board endorsement to be formalised and document to be presented to the General Assembly
+- Maintainer Committee outstanding quarterly reports – one additional month granted
+- Shared password manager – proposal with pricing to be drafted and submitted to the General Assembly for decision
+- Quarterly board meeting scheduled for Wednesday, 29 April 2026
+- Open coding session format and categories – follow-up ongoing
+- PRAGMA board Discord server removal – pending legal confirmation from counsel
+


### PR DESCRIPTION
Documented the details of the Validity Review 20 meeting held on April 8, 2026, including attendees, agenda items, and follow-up notes.